### PR TITLE
Update kube to 0.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "argh"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91792f088f87cdc7a2cfb1d617fa5ea18d7f1dc22ef0e1b5f82f3157cdc522be"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4eb0c0c120ad477412dc95a4ce31e38f2113e46bd13511253f79196ca68b067"
+dependencies = [
+ "argh_shared",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
+
+[[package]]
 name = "array_tool"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +757,7 @@ dependencies = [
 name = "kube-example-cnat"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "chrono",
  "futures",
  "futures-util",
@@ -1774,6 +1813,12 @@ checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,8 +672,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.43.0"
-source = "git+https://github.com/clux/kube-rs?rev=73f02689b12198631e1eb035cae0592056bb10e8#73f02689b12198631e1eb035cae0592056bb10e8"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585da8efec1a3b5df0fb12b357e2f3921cd7436a6d10f1ea06377d4cbd85032"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -703,8 +704,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.43.0"
-source = "git+https://github.com/clux/kube-rs?rev=73f02689b12198631e1eb035cae0592056bb10e8#73f02689b12198631e1eb035cae0592056bb10e8"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0101a3777e606d7204aa830a9affcb328767912e406932f53704c6efbcf9afa4"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -736,8 +738,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.43.0"
-source = "git+https://github.com/clux/kube-rs?rev=73f02689b12198631e1eb035cae0592056bb10e8#73f02689b12198631e1eb035cae0592056bb10e8"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b01bed1a72a06d987a98d28b49e70c9e43f600720348a48d48291d94ba003f6"
 dependencies = [
  "dashmap",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "cnat"
 path = "src/main.rs"
 
 [dependencies]
+argh = "0.1.4"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.5"
 futures-util = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.5"
 futures-util = "0.3.5"
-kube = { version = "0.43.0", default-features = true, features = ["derive"] }
-kube-derive = "0.43.0"
-kube-runtime = "0.43.0"
+kube = { version = "0.44.0", features = ["derive"] }
+kube-derive = "0.44.0"
+kube-runtime = "0.44.0"
 k8s-openapi = { version = "0.10.0", default-features = false, features = ["v1_19"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -30,12 +30,6 @@ tokio = { version = "^0.2.24", features = ["macros", "rt-core"] }
 log = "0.4.11"
 simple_logger = { version = "1.11.0", default-features = false }
 schemars = { version = "0.8.0", features = ["chrono"] }
-
-[patch.crates-io]
-# Try kube with schema generation support
-kube = { git = "https://github.com/clux/kube-rs", rev = "73f02689b12198631e1eb035cae0592056bb10e8" }
-kube-derive = { git = "https://github.com/clux/kube-rs", rev = "73f02689b12198631e1eb035cae0592056bb10e8" }
-kube-runtime = { git = "https://github.com/clux/kube-rs", rev = "73f02689b12198631e1eb035cae0592056bb10e8" }
 
 [profile.release]
 lto = true

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     MissingObjectKey(&'static str),
     #[error("Timed out: {0}")]
     TimedOut(String),
+    #[error("Missing CRD")]
+    MissingCRD,
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use argh::FromArgs;
 use kube::Client;
 use simple_logger::SimpleLogger;
 
@@ -5,14 +6,37 @@ mod controller;
 mod crd;
 mod error;
 
-use crate::error::Result;
+use crd::At;
+use error::{Error, Result};
+
+#[derive(FromArgs)]
+/// Cloud native `at` command.
+struct Options {
+    /// output CustomResourceDefinition to stdout and exit
+    #[argh(switch, short = 'g')]
+    gen_crd: bool,
+    /// automatically install the current CRD if missing, assuming permission to modify CRDs
+    #[argh(switch, short = 'a')]
+    auto_install: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let opts: Options = argh::from_env();
+    if opts.gen_crd {
+        println!("{}", serde_yaml::to_string(&At::crd()).unwrap());
+        return Ok(());
+    }
+
     SimpleLogger::from_env().init().unwrap();
 
     let client = Client::try_default().await?;
     if !crd::exists(client.clone()).await {
+        if !opts.auto_install {
+            eprintln!("CRD is not installed. Generate and apply before running or use auto-install option.");
+            return Err(Error::MissingCRD);
+        }
+
         log::info!("Creating At CRD");
         crd::create(client.clone()).await?;
         crd::wait_for_ready(client.clone(), 5).await?;


### PR DESCRIPTION
Also, stop auto-installing by default and provide options.

Generate and apply:
```
cnat --gen-crd | kubectl apply -f -
cnat -g | kubectl apply -f -
```

If permission allows, auto-install the current version:
```
cnat --auto-install
cnat -a
```